### PR TITLE
updated to version 0.3.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.2.3" %}
+{% set version = "0.3.0" %}
 
 package:
   name: pyugrid
@@ -7,7 +7,7 @@ package:
 source:
   fn: pyugrid-{{ version }}.tar.gz
   url: https://github.com/pyugrid/pyugrid/archive/v{{ version }}.tar.gz
-  sha256: 5958728eaaf12c9a3bc51b32b87f22cca6c82b5fcb7fb2038ae2ebce7f2f46f7
+  sha256: da10953f66fec2320688790f63332b8458952742694ff6e4daa765d2ea6bdcde
 
 build:
   number: 0


### PR DESCRIPTION
I couldn't get this to build no my personal maching with python2.7, due to a very odd "can't import setuptools" error -- even though setuptools is clearly being installed into the build environment...

But it builds with python3.6 fine.

I've lost track of when the CIs run to build for conda-forge, but here's the PR in any case.


